### PR TITLE
Feat: CORS 설정 추가 (localhost:3000)

### DIFF
--- a/src/main/java/com/awesomedesk/j_planner/config/CorsConfig.java
+++ b/src/main/java/com/awesomedesk/j_planner/config/CorsConfig.java
@@ -1,0 +1,19 @@
+package com.awesomedesk.j_planner.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## 개요

로컬 개발 환경에서 프론트엔드(React 등)와 백엔드 API 간 통신 시 CORS(Cross-Origin Resource Sharing) 에러가 발생하여, 개발 환경에서 원활한 통신을 위해 CORS 설정을 추가했습니다.

## 작업한 내용

- `CorsConfig.java` 파일 추가
  - WebMvcConfigurer 인터페이스를 구현하여 CORS 정책 설정
  - 허용 Origin: `http://localhost:3000` (프론트엔드 개발 서버)
  - 허용 HTTP 메서드: GET, POST, PUT, DELETE, PATCH, OPTIONS
  - 모든 헤더 허용
  - Credentials(쿠키, 인증 헤더 등) 허용
  - Preflight 요청 캐싱 시간: 3600초 (1시간)

## 리뷰 가이드

- CORS 설정이 로컬 개발 환경에만 적용되는 것이 맞는지 확인 부탁드립니다
- 보안을 위해 프로덕션 환경에서는 별도의 CORS 설정이 필요할 수 있습니다
- 현재는 모든 헤더를 허용하고 있는데, 필요시 특정 헤더만 허용하도록 제한할 수 있습니다

## 테스트 결과

로컬 환경에서 테스트가 필요합니다:
- [x] `./gradlew bootRun`으로 애플리케이션 실행
- [x] localhost:3000에서 실행 중인 프론트엔드에서 API 호출
- [x] CORS 에러가 발생하지 않는지 확인
- [x] Preflight OPTIONS 요청이 정상적으로 처리되는지 브라우저 개발자 도구에서 확인

## 앞으로 추가 예정 내용

- 프로덕션 환경을 위한 CORS 설정 (실제 프론트엔드 도메인으로 제한)
- 프로필별(local/test/prod) CORS 설정 분리 검토

## 기타 내용

- 로컬 개발 환경에서만 사용하는 설정이므로, 추후 환경별 설정 분리 필요

## 이슈번호

[#11]